### PR TITLE
chore(release): v0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.4] - July 15, 2026
+
+### Added
+- Critical dependencies updated via dependabot: Vite and npm_and_yarn dependency group
+- Style adjustments required after the latest Vite update to maintain visual compatibility
+- Resolved CVE-2026-33532 vulnerability and related issues via npm overrides
+
 ## [0.4.3] - June 10, 2026
 
 ### Added
@@ -19,15 +26,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Scripts for automated roadmap translation sync and CHANGELOG.md generation
 - Removed orphaned scripts (roadmap-gen.js), unused roadmap.old-* translation keys, duplicate files deleted
 
-## [0.4.2] - April 1, 2026
-
-### Added
-- The native browser confirm() is being phased out, so a custom confirmation modal was implemented, aligned with the app's design.
-- The floating menu appeared in different positions between the web version and the installed PWA, so a dynamic script was implemented to calculate the correct position in both contexts.
-- Tests cover new and modified features. The tab closing logic was moved to a modular standalone script, and tests were added for the floating menu and tab close confirmation.
-- The 'alert' and 'trash' icons were added to provide a clearer representation of the tab closing flow for users.
-- The text editor now includes global styles for consistent rendering, especially optimized for content pasted from external web pages.
-
 ### Previous Versions
 
 <details>
@@ -37,6 +35,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Dynamic floating menu positioning, safe area insets support for iOS PWA, virtual keyboard detection, fixed positioning in standalone mode
 - Added alert and trash icons
 - 19 new tests added for confirmation, tab deletion and floating menu modules. Total: 163 passing tests
+
+</details>
+
+<details>
+<summary>[0.4.3] - June 10, 2026</summary>
+
+- All components restructured into src/features/ as self-contained modules: FloatingMenu, ContextualMenu, ModalInfo, CreateTab, CloseTabConfirmation, and Roadmap
+- Custom <dialog> element for tab deletion, replacing the native browser confirm()
+- ARIA attributes on modals, improved keyboard navigation, screen reader support
+- Google Search Console verification meta tag, BreadcrumbList and HowTo schemas, 3 new SEO views, default hreflang set to 'en', AI agent indexing (Google, GPT, Anthropic)
+- Floating menu position auto-adjusts based on install mode (PWA vs browser), tablet and mobile display corrections, pasted text preserves its original structure
+- All comments and test descriptions translated to English, contextual menu and confirmation modal translation
+- Removed outline on [contenteditable]:focus, added global dialog::backdrop, --nav-bottom adjusted to 1rem, removed redundant font styles
+- 6 icons added: close button, rocket, file-text, chevron-right, alert, and trash
+- New Roadmap tab replacing the News tab, with i18n integration and automated sync from roadmap-data.json
+- Scripts for automated roadmap translation sync and CHANGELOG.md generation
+- Removed orphaned scripts (roadmap-gen.js), unused roadmap.old-* translation keys, duplicate files deleted
 
 </details>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "notepad-astro",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "notepad-astro",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "dependencies": {
         "@astrojs/check": "^0.9.6",
         "@tailwindcss/vite": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "notepad-astro",
   "type": "module",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "scripts": {
     "sync:roadmap": "node scripts/sync-roadmap-locales.cjs",
     "changelog": "node scripts/generate-changelog.cjs",

--- a/src/features/modal-info/modal-info.astro
+++ b/src/features/modal-info/modal-info.astro
@@ -43,7 +43,7 @@ const navItems = [
             TomaNote
           </h2>
           <p id="settings-desc" class="sr-only">Settings and preferences for TomaNote app</p>
-          <span class="version text-sm! text-(--color-text)">v 0.4.3</span>
+          <span class="version text-sm! text-(--color-text)">v 0.4.4</span>
         </div>
 
         <nav class="settings-nav bg-(--tn-neutral-tertiary-color)/10 rounded-lg mt-[16px]! px-[5px]!">

--- a/src/features/roadmap/roadmap-data.json
+++ b/src/features/roadmap/roadmap-data.json
@@ -3,39 +3,14 @@
     {
       "id": "prev",
       "type": "previous",
-      "versionNumber": "0.4.2",
-      "date": "2026-04-01",
-      "isCurrent": false,
-      "isNext": false,
-      "items": {
-        "es": [
-          { "summary": "Modal de confirmacion para eliminar pestañas", "description": "El método nativo confirm() del navegador está siendo desincentivado. Se implementó un modal de confirmación personalizado, alineado con los estilos y la experiencia del aplicativo." },
-          { "summary": "Posicionamiento del Floating Menu", "description": "Se corrigió la inconsistencia de posicionamiento del menú flotante entre web y PWA mediante un cálculo dinámico basado en el contexto de renderizado." },
-          { "summary": "Se agregaron 19 test adicionales", "description": "Se implementaron pruebas para las nuevas funcionalidades y cambios realizados. La lógica de cierre de pestañas fue modularizada en un script independiente, y se añadieron tests para el menú flotante y la confirmación de cierre." },
-          { "summary": "Se añadieron 2 nuevos iconos", "description": "Se incorporaron los iconos 'alert' y 'trash' para representar de forma más clara el flujo de cierre de pestañas para los usuarios." },
-          { "summary": "Nuevos estilos para el editor de texto", "description": "El editor de texto ahora incluye estilos globales para una visualización consistente, especialmente optimizados para contenido pegado desde otras páginas web." }
-        ],
-        "en": [
-          { "summary": "Tab deletion confirmation modal", "description": "The native browser confirm() is being phased out, so a custom confirmation modal was implemented, aligned with the app's design." },
-          { "summary": "Floating menu positioning", "description": "The floating menu appeared in different positions between the web version and the installed PWA, so a dynamic script was implemented to calculate the correct position in both contexts." },
-          { "summary": "19 additional tests added", "description": "Tests cover new and modified features. The tab closing logic was moved to a modular standalone script, and tests were added for the floating menu and tab close confirmation." },
-          { "summary": "2 new icons added", "description": "The 'alert' and 'trash' icons were added to provide a clearer representation of the tab closing flow for users." },
-          { "summary": "New text editor styles", "description": "The text editor now includes global styles for consistent rendering, especially optimized for content pasted from external web pages." }
-        ]
-      }
-    },
-    {
-      "id": "current",
-      "type": "current",
       "versionNumber": "0.4.3",
       "date": "2026-06-10",
-      "isCurrent": true,
+      "isCurrent": false,
       "isNext": false,
       "items": {
         "es": [
           { "summary": "Modularización completa", "description": "Todos los componentes se reestructuraron en src/features/ como módulos independientes: FloatingMenu, ContextualMenu, ModalInfo, CreateTab, CloseTabConfirmation y Roadmap" },
           { "summary": "Modal de confirmación", "description": "Nuevo diálogo <dialog> personalizado para eliminar pestañas, reemplazando el obsoleto confirm() nativo del navegador" },
-          { "summary": "Soporte para PWA", "description": "Ahora la aplicación funciona offline y puede instalarse como app nativa" },
           { "summary": "Mejoras de accesibilidad", "description": "Atributos ARIA en modales, navegación por teclado mejorada, soporte para lectores de pantalla" },
           { "summary": "Optimización SEO", "description": "Meta tag de verificación de Google Search Console, esquemas BreadcrumbList y HowTo, 3 nuevas vistas SEO, hreflang por defecto en 'en', indexación para agentes IA (Google, GPT, Anthropic)" },
           { "summary": "Correcciones de UI", "description": "Posición del menú flotante se ajusta según modo de instalación (PWA vs navegador), correcciones en tablet y móvil, texto pegado preserva su estructura original" },
@@ -58,6 +33,26 @@
           { "summary": "Roadmap", "description": "New Roadmap tab replacing the News tab, with i18n integration and automated sync from roadmap-data.json" },
           { "summary": "Automation", "description": "Scripts for automated roadmap translation sync and CHANGELOG.md generation" },
           { "summary": "Cleanup", "description": "Removed orphaned scripts (roadmap-gen.js), unused roadmap.old-* translation keys, duplicate files deleted" }
+        ]
+      }
+    },
+    {
+      "id": "current",
+      "type": "current",
+      "versionNumber": "0.4.4",
+      "date": "2026-07-15",
+      "isCurrent": true,
+      "isNext": false,
+      "items": {
+        "es": [
+          { "summary": "Actualización de dependencias", "description": "Dependencias críticas actualizadas mediante dependabot: Vite y grupo de dependencias npm_and_yarn" },
+          { "summary": "Corrección de estilos para Vite", "description": "Ajustes de estilos requeridos tras la última actualización de Vite para mantener la compatibilidad visual" },
+          { "summary": "Parche de seguridad CVE-2026-33532", "description": "Resuelta vulnerabilidad CVE-2026-33532 y vulnerabilidades relacionadas mediante overrides en npm" }
+        ],
+        "en": [
+          { "summary": "Dependency updates", "description": "Critical dependencies updated via dependabot: Vite and npm_and_yarn dependency group" },
+          { "summary": "Vite style fix", "description": "Style adjustments required after the latest Vite update to maintain visual compatibility" },
+          { "summary": "Security patch CVE-2026-33532", "description": "Resolved CVE-2026-33532 vulnerability and related issues via npm overrides" }
         ]
       }
     },
@@ -102,6 +97,44 @@
           { "summary": "Mobile & PWA improvements", "description": "Dynamic floating menu positioning, safe area insets support for iOS PWA, virtual keyboard detection, fixed positioning in standalone mode" },
           { "summary": "New icons", "description": "Added alert and trash icons" },
           { "summary": "Testing", "description": "19 new tests added for confirmation, tab deletion and floating menu modules. Total: 163 passing tests" }
+        ]
+      }
+    },
+    {
+      "id": "old-043",
+      "type": "old",
+      "versionNumber": "0.4.3",
+      "date": "2026-06-10",
+      "isCurrent": false,
+      "isNext": false,
+      "isOld": true,
+      "showInTab": false,
+      "items": {
+        "es": [
+          { "summary": "Modularización completa", "description": "Todos los componentes se reestructuraron en src/features/ como módulos independientes: FloatingMenu, ContextualMenu, ModalInfo, CreateTab, CloseTabConfirmation y Roadmap" },
+          { "summary": "Modal de confirmación", "description": "Nuevo diálogo <dialog> personalizado para eliminar pestañas, reemplazando el obsoleto confirm() nativo del navegador" },
+          { "summary": "Mejoras de accesibilidad", "description": "Atributos ARIA en modales, navegación por teclado mejorada, soporte para lectores de pantalla" },
+          { "summary": "Optimización SEO", "description": "Meta tag de verificación de Google Search Console, esquemas BreadcrumbList y HowTo, 3 nuevas vistas SEO, hreflang por defecto en 'en', indexación para agentes IA (Google, GPT, Anthropic)" },
+          { "summary": "Correcciones de UI", "description": "Posición del menú flotante se ajusta según modo de instalación (PWA vs navegador), correcciones en tablet y móvil, texto pegado preserva su estructura original" },
+          { "summary": "Internacionalización", "description": "Todos los comentarios y descripciones de tests traducidos al inglés, traducciones para menú contextual y modal de confirmación" },
+          { "summary": "Actualización de estilos", "description": "Eliminado outline en [contenteditable]:focus, agregado dialog::backdrop global, ajuste de --nav-bottom a 1rem, eliminados estilos de fuente redundantes" },
+          { "summary": "Nuevos iconos", "description": "6 iconos añadidos: botón cerrar, cohete, file-text, chevron-right, alerta y papelera" },
+          { "summary": "Roadmap", "description": "Nueva pestaña Roadmap reemplaza la pestaña Novedades, con integración i18n y sincronización automatizada desde roadmap-data.json" },
+          { "summary": "Automatización", "description": "Scripts para sincronización automática de traducciones del roadmap y generación de CHANGELOG.md" },
+          { "summary": "Limpieza", "description": "Scripts huérfanos eliminados (roadmap-gen.js), claves de traducción roadmap.old-* sin uso removidas, archivos duplicados eliminados" }
+        ],
+        "en": [
+          { "summary": "Full modularization", "description": "All components restructured into src/features/ as self-contained modules: FloatingMenu, ContextualMenu, ModalInfo, CreateTab, CloseTabConfirmation, and Roadmap" },
+          { "summary": "Confirmation modal", "description": "Custom <dialog> element for tab deletion, replacing the native browser confirm()" },
+          { "summary": "Accessibility improvements", "description": "ARIA attributes on modals, improved keyboard navigation, screen reader support" },
+          { "summary": "SEO optimization", "description": "Google Search Console verification meta tag, BreadcrumbList and HowTo schemas, 3 new SEO views, default hreflang set to 'en', AI agent indexing (Google, GPT, Anthropic)" },
+          { "summary": "UI fixes", "description": "Floating menu position auto-adjusts based on install mode (PWA vs browser), tablet and mobile display corrections, pasted text preserves its original structure" },
+          { "summary": "Internationalization", "description": "All comments and test descriptions translated to English, contextual menu and confirmation modal translation" },
+          { "summary": "Style updates", "description": "Removed outline on [contenteditable]:focus, added global dialog::backdrop, --nav-bottom adjusted to 1rem, removed redundant font styles" },
+          { "summary": "New icons", "description": "6 icons added: close button, rocket, file-text, chevron-right, alert, and trash" },
+          { "summary": "Roadmap", "description": "New Roadmap tab replacing the News tab, with i18n integration and automated sync from roadmap-data.json" },
+          { "summary": "Automation", "description": "Scripts for automated roadmap translation sync and CHANGELOG.md generation" },
+          { "summary": "Cleanup", "description": "Removed orphaned scripts (roadmap-gen.js), unused roadmap.old-* translation keys, duplicate files deleted" }
         ]
       }
     },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -155,5 +155,17 @@
   "roadmap.next.1.summary": "Live Markdown preview",
   "roadmap.next.1.description": "Write in Markdown and see the result rendered in real time directly in your note.",
   "roadmap.next.2.summary": "Global search",
-  "roadmap.next.2.description": "Search among your notes, either by title or directly by note content."
+  "roadmap.next.2.description": "Search among your notes, either by title or directly by note content.",
+  "roadmap.prev.5.summary": "Internationalization",
+  "roadmap.prev.5.description": "All comments and test descriptions translated to English, contextual menu and confirmation modal translation",
+  "roadmap.prev.6.summary": "Style updates",
+  "roadmap.prev.6.description": "Removed outline on [contenteditable]:focus, added global dialog::backdrop, --nav-bottom adjusted to 1rem, removed redundant font styles",
+  "roadmap.prev.7.summary": "New icons",
+  "roadmap.prev.7.description": "6 icons added: close button, rocket, file-text, chevron-right, alert, and trash",
+  "roadmap.prev.8.summary": "Roadmap",
+  "roadmap.prev.8.description": "New Roadmap tab replacing the News tab, with i18n integration and automated sync from roadmap-data.json",
+  "roadmap.prev.9.summary": "Automation",
+  "roadmap.prev.9.description": "Scripts for automated roadmap translation sync and CHANGELOG.md generation",
+  "roadmap.prev.10.summary": "Cleanup",
+  "roadmap.prev.10.description": "Removed orphaned scripts (roadmap-gen.js), unused roadmap.old-* translation keys, duplicate files deleted"
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -158,5 +158,17 @@
   "roadmap.next.1.summary": "Visualización en vivo de Markdown",
   "roadmap.next.1.description": "Escribe en markdown y ve el resultado renderizado en tiempo real directamente en tu nota.",
   "roadmap.next.2.summary": "Búsqueda global",
-  "roadmap.next.2.description": "Busca entre tus notas, ya sea por titulo o directamente contenido de la nota"
+  "roadmap.next.2.description": "Busca entre tus notas, ya sea por titulo o directamente contenido de la nota",
+  "roadmap.prev.5.summary": "Internacionalización",
+  "roadmap.prev.5.description": "Todos los comentarios y descripciones de tests traducidos al inglés, traducciones para menú contextual y modal de confirmación",
+  "roadmap.prev.6.summary": "Actualización de estilos",
+  "roadmap.prev.6.description": "Eliminado outline en [contenteditable]:focus, agregado dialog::backdrop global, ajuste de --nav-bottom a 1rem, eliminados estilos de fuente redundantes",
+  "roadmap.prev.7.summary": "Nuevos iconos",
+  "roadmap.prev.7.description": "6 iconos añadidos: botón cerrar, cohete, file-text, chevron-right, alerta y papelera",
+  "roadmap.prev.8.summary": "Roadmap",
+  "roadmap.prev.8.description": "Nueva pestaña Roadmap reemplaza la pestaña Novedades, con integración i18n y sincronización automatizada desde roadmap-data.json",
+  "roadmap.prev.9.summary": "Automatización",
+  "roadmap.prev.9.description": "Scripts para sincronización automática de traducciones del roadmap y generación de CHANGELOG.md",
+  "roadmap.prev.10.summary": "Limpieza",
+  "roadmap.prev.10.description": "Scripts huérfanos eliminados (roadmap-gen.js), claves de traducción roadmap.old-* sin uso removidas, archivos duplicados eliminados"
 }


### PR DESCRIPTION
## Summary
- Bump version to 0.4.4
- New roadmap entry for v0.4.4: dependency updates, Vite style fix, security patch CVE-2026-33532
- Rotate roadmap: 0.4.3 moves to previous, 0.4.4 becomes current
- Update version display in modal-info
- Regenerate CHANGELOG.md and sync roadmap translations
- Clean up stale branches (update-issues, update-design, update-seo, update-testing)

## Changes
- `src/features/roadmap/roadmap-data.json` — new v0.4.4 current entry, v0.4.3 moved to previous
- `src/features/modal-info/modal-info.astro` — version 0.4.3 → 0.4.4
- `CHANGELOG.md` — regenerated from roadmap data
- `src/locales/es.json` / `src/locales/en.json` — synced roadmap translations
- `package.json` / `package-lock.json` — bumped to 0.4.4

## Verification
- All 267 tests passing
- Production build successful
- Tag `v0.4.4` created