### PR TITLE
Release v0.5.1 hotfixes + project conventions (docs, CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: Continuous Integration (CI)
+
+on:
+  pull_request:
+    branches: [master, dev]
+  push:
+    branches: [master]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type-check with Astro
+        run: npx astro check
+
+      - name: Run unit tests
+        run: npm run test:run
+
+      - name: Production build
+        run: npm run build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - New interactive overlay listing all keyboard shortcuts grouped by category (Tabs, Navigation, Editor). Accessible via sidebar button or Alt+/.
 - Enhanced settings modal navigation — Enter/Space jumps into tab content, Escape returns to sidebar, arrows no longer intercepted inside form controls.
 - Escape in the command palette no longer propagates to the global shortcut system, preventing accidental tab closing.
+- Theme color radio buttons restored to the tab order inside the settings modal.
+- Arrow keys navigate from the focused settings sidebar item.
+- Focus-visible rings added for the navigation bar, save and font-size labels.
+- Alt+number shortcuts no longer trigger from the numeric keypad.
+- Editor no longer auto-scrolls when changing the font size on mobile.
+- New tabs now apply the saved font size.
+- The 'View full changelog' link points back to the correct URL.
+- Console logs are now restricted to development builds to keep the production bundle clean.
 
 ## [0.5.0] - July 19, 2026
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,127 @@
+# Contributing to TomaNote
+
+First of all, thanks for taking the time to contribute! This is a community-driven, open source project and any help is welcome — bug reports, feature proposals, or code improvements.
+
+Please follow the guidelines below to keep the project organized and running smoothly.
+
+---
+
+## Project overview
+
+- **Language / framework**: Astro (SSG) + Tailwind CSS + SCSS, TypeScript checked, JavaScript runtime modules.
+- **Runtime**: Node.js >= 22.12.0.
+- **Branches**: `master` is the default branch; `dev` is the integration branch. Never work directly on either of them.
+- **i18n**: English (US) and Spanish (CO). All user-facing strings must go through the locale files.
+
+---
+
+## Getting started
+
+1. **Fork** the repository.
+2. **Clone** your fork locally:
+
+   ```bash
+   git clone https://github.com/Tomanote/TomaNote.git
+   cd TomaNote
+   ```
+
+3. Add the original repository as an upstream remote (to stay in sync):
+
+   ```bash
+   git remote add upstream https://github.com/Tomanote/TomaNote.git
+   ```
+
+4. **Create a branch** for your work. Use a descriptive name with the matching prefix:
+
+   ```bash
+   git checkout -b feature/your-feature-name
+   git checkout -b fix/your-bugfix-name
+   git checkout -b hotfix/your-hotfix-name   # urgent production fix
+   ```
+
+5. **Install dependencies** with the exact lockfile versions:
+
+   ```bash
+   npm ci
+   ```
+
+---
+
+## Development scripts
+
+| Command              | Description                                            |
+| -------------------- | ------------------------------------------------------ |
+| `npm run dev`        | Starts the Astro dev server (syncs roadmap first)      |
+| `npm run test`       | Runs unit tests with Vitest in watch mode              |
+| `npm run test:run`   | Runs all unit tests once (run this before pushing)     |
+| `npm run build`      | Production build (syncs roadmap + generates changelog) |
+| `npm run changelog`  | Regenerates `CHANGELOG.md` from `roadmap-data.json`    |
+| `npm run sync:roadmap` | Syncs roadmap translations into the locale files      |
+| `npm run security:check` | Audits dependencies for high/critical vulnerabilities |
+| `npx astro check`    | Type-checks the Astro project                          |
+
+---
+
+## Git workflow (strict)
+
+1. **Never push directly to `master`.** All contributions must go through a **Pull Request**.
+2. Feature branches are merged into **`dev`** first via PR. The owner reviews and merges `dev` → `master` manually.
+3. `master` has branch protection: a PR is required and the `build-and-test` status check must pass before merging.
+4. **Keep commits self-contained and independently revertable.** Each commit should represent one logical change and leave the project in a working state.
+
+### Conventional commits
+
+Use [Conventional Commits](https://www.conventionalcommits.org/) — `type(scope): description` in English:
+
+- `feat(scope): add ...`
+- `fix(scope): correct ...`
+- `refactor(scope): restructure ...`
+- `docs(scope): update ...`
+- `test(scope): cover ...`
+- `chore(scope): ...`
+
+Examples: `fix(editor): apply saved font-size to new tabs`, `docs(roadmap): add v0.5.1 entries`.
+
+### Code quality (required before opening a PR)
+
+All of the following must pass locally:
+
+- `npm run test:run` — the full test suite.
+- `npm run build` — the production build must assemble correctly.
+- `npx astro check` — no TypeScript errors.
+
+If any of these fail, fix them before opening the PR.
+
+---
+
+## CI / CD
+
+GitHub Actions runs several automated checks:
+
+- **`build-and-test`** (`.github/workflows/ci.yml`): runs `astro check`, the unit tests, and the production build on every PR to `master`/`dev` and on pushes to `master`. **This check blocks the merge** if it fails.
+- **Security audit** (`.github/workflows/security.yml`): runs `npm audit` and an outdated-dependency report on every PR and push. It is **informational only** and does not block merges.
+- **Deploy** (`.github/workflows/deploy.yml`): builds and publishes to GitHub Pages on every push to `master`.
+
+**Deploy note**: the site is served from the `gh-pages` branch via GitHub Pages. A `.nojekyll` file must always be present in `dist/` — without it, Jekyll ignores the `_astro/` folder and the site renders blank. The deploy script uses `gh-pages -d dist -t` (the `-t` flag publishes dotfiles).
+
+---
+
+## Code conventions
+
+- **Feature-based structure**: components live in `src/features/[name]/` as self-contained modules (Astro component, SCSS styles, JS logic, tests). See the existing features before creating a new one.
+- **Class-based JS modules** with an `init()` pattern (`TabManager`, `ContextMenu`, etc.).
+- **i18n**: never hardcode user-facing strings. Use the client i18n core in JS modules and the typed server i18n in `.astro` files. Both `en.json` and `es.json` must stay in sync.
+- **Roadmap**: `src/features/roadmap/roadmap-data.json` is the single source of truth. `npm run sync:roadmap` and `npm run changelog` only read from it — do not edit the generated locale keys or `CHANGELOG.md` by hand.
+- **Logging**: use the `devLogger` utility instead of raw `console.*`. Console output is gated to development builds, keeping the production bundle clean.
+
+---
+
+## Reporting issues / proposing changes
+
+- Found a bug? Open an **Issue** using the `Bug Report` template.
+- Want to propose a large change before coding it? Open an **Issue** or start a discussion first.
+- When opening a PR, fill out the PR template so reviewers understand your change.
+
+---
+
+Thanks again for helping make TomaNote better! 🚀

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 <div align="center">
 
-![Version](https://img.shields.io/badge/version-0.5.0-blue.svg)
+![Version](https://img.shields.io/badge/version-0.5.1-blue.svg)
 ![License](https://img.shields.io/badge/license-AGPL%20v3-green.svg)
 ![Status](https://img.shields.io/badge/status-active-success.svg)
 ![Mobile](https://img.shields.io/badge/mobile-responsive-success)
 
-[Live Demo](https://tomanote.app) | [Report a Bug](https://github.com/Mixxy-Studio/TomaNote/issues) | [Request a Feature](https://github.com/Mixxy-Studio/TomaNote/issues)
+[Live Demo](https://tomanote.app) | [Report a Bug](https://github.com/Tomanote/TomaNote/issues) | [Request a Feature](https://github.com/Tomanote/TomaNote/issues)
 
 [!["Buy Me A Coffee"](https://img.shields.io/badge/Buy_Me_A_Coffee-FFDD00?style=for-the-badge&logo=buy-me-a-coffee&logoColor=black)](https://buymeacoffee.com/dftp930)
 
@@ -20,27 +20,27 @@ TomaNote is a modern, minimalist notepad that runs directly in your browser. No 
 > Want to see what's coming next?
 > Check the **Roadmap** inside the app at [tomanote.app](https://tomanote.app) ✨
 
-## 🚀 What's new — v0.5.0
+## 🚀 What's new — v0.5.1
 
-This release focuses on editor customization, a modern command palette, and major layout improvements.
+This release revamps keyboard navigation with a centralized shortcut system, adds a shortcuts help overlay, and ships a batch of accessibility and mobile fixes.
 
-### ⚙️ Editor settings
-New Appearance tab with editor width control and paper background color customization.
+### ⌨️ Keyboard shortcuts system
+Centralized class-based shortcut system with modifier matching (Ctrl/Alt/Shift/Meta), scope guards, and automatic desktop detection.
 
-### 🔍 Command palette
-Global search with Spotlight-style UI — search notes by title or content instantly.
+### 🗺️ Shortcuts help overlay
+New interactive overlay listing all keyboard shortcuts grouped by category. Accessible via the sidebar button or `Alt+/`.
 
-### 📱 Responsive layout
-Left sidebar on desktop, bottom navigation bar on mobile, floating menu reorganized as a right sidebar.
+### 🧭 Settings modal navigation
+Enhanced settings modal navigation — Enter/Space jumps into tab content, Escape returns to sidebar, arrows no longer intercepted inside form controls.
 
-### 🎨 Theme system
-CSS variables applied consistently across UI components including command palette and previews.
-
-### 📏 Tooltips
-All buttons now have smart tooltips with sidebar-aware positioning.
+### 🔧 Hotfixes
+- Theme color radios restored to tab order; arrow keys navigate from the focused sidebar item; visible focus rings added.
+- Alt+number shortcuts no longer trigger from the numpad.
+- New tabs now apply the saved font size; no more auto-scroll on mobile.
+- Console logs gated to development builds; changelog link restored.
 
 ### 🧪 Test coverage
-455 tests passing — expanded coverage for editor settings, command palette, floating menu, and utilities.
+508 tests passing.
 
 ## 🛠️ Tech Stack
 
@@ -60,7 +60,7 @@ All buttons now have smart tooltips with sidebar-aware positioning.
 
 ```bash
 # Clone the repo
-git clone https://github.com/Mixxy-Studio/TomaNote.git
+git clone https://github.com/Tomanote/TomaNote.git
 
 # Install dependencies
 npm install

--- a/scripts/sync-roadmap-locales.cjs
+++ b/scripts/sync-roadmap-locales.cjs
@@ -33,12 +33,16 @@ function syncRoadmapLocales() {
     es: {
       "roadmap.badge.current": "ACTUAL",
       "roadmap.badge.next": "PRÓXIMO",
-      "roadmap.badge.previous": "ANTERIOR"
+      "roadmap.badge.previous": "ANTERIOR",
+      "roadmap.viewChangelog": "Ver changelog completo →",
+      "roadmap.changelog-link": "https://github.com/Tomanote/TomaNote/blob/master/CHANGELOG.md"
     },
     en: {
       "roadmap.badge.current": "CURRENT",
       "roadmap.badge.next": "NEXT",
-      "roadmap.badge.previous": "PREVIOUS"
+      "roadmap.badge.previous": "PREVIOUS",
+      "roadmap.viewChangelog": "View full changelog →",
+      "roadmap.changelog-link": "https://github.com/Tomanote/TomaNote/blob/master/CHANGELOG.md"
     }
   };
 

--- a/src/features/command-palette/command-palette.js
+++ b/src/features/command-palette/command-palette.js
@@ -1,6 +1,8 @@
 // src/features/command-palette/command-palette.js
 // Command Palette - Global search and navigation
 
+import { devLogger } from "../../lib/scripts/utils/devLogger.js";
+
 export class CommandPalette {
   constructor(options = {}) {
     this.options = {
@@ -320,7 +322,7 @@ export class CommandPalette {
 
   log(...args) {
     if (this.options.debug) {
-      console.log("[CommandPalette]", ...args);
+      devLogger.log("[CommandPalette]", ...args);
     }
   }
 }

--- a/src/features/floating-menu/floating-menu.js
+++ b/src/features/floating-menu/floating-menu.js
@@ -3,6 +3,7 @@
 
 import { FormattingUtils } from "../../lib/scripts/utils/formatting.js";
 import { detectEmojiInText, getRandomPinEmoji } from "../../lib/scripts/utils/emojiDetector.js";
+import { devLogger } from "../../lib/scripts/utils/devLogger.js";
 
 export class FloatingMenu {
   constructor(options = {}) {
@@ -590,7 +591,7 @@ export class FloatingMenu {
 
   log(...args) {
     if (this.options.debug) {
-      console.log("[FloatingMenu]", ...args);
+      devLogger.log("[FloatingMenu]", ...args);
     }
   }
 }

--- a/src/features/keyboard-shortcuts-help/keyboard-shortcuts-help.js
+++ b/src/features/keyboard-shortcuts-help/keyboard-shortcuts-help.js
@@ -1,6 +1,8 @@
 // src/features/keyboard-shortcuts-help/keyboard-shortcuts-help.js
 // Keyboard shortcuts help overlay
 
+import { devLogger } from "../../lib/scripts/utils/devLogger.js";
+
 export class KeyboardShortcutsHelp {
   constructor(options = {}) {
     this.options = {
@@ -116,7 +118,7 @@ export class KeyboardShortcutsHelp {
 
   log(...args) {
     if (this.options.debug) {
-      console.log("[KeyboardShortcutsHelp]", ...args);
+      devLogger.log("[KeyboardShortcutsHelp]", ...args);
     }
   }
 }

--- a/src/features/modal-info/components/tabs/AppearanceTab.astro
+++ b/src/features/modal-info/components/tabs/AppearanceTab.astro
@@ -18,7 +18,7 @@
       <div class="col-span-2">
         <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-2 xl:grid-cols-3 gap-4!">
           <div class="group">
-            <input type="radio" name="themeColor" id="theme-color-dark" class="hidden peer" checked />
+            <input type="radio" name="themeColor" id="theme-color-dark" class="sr-only peer" checked />
             <label for="theme-color-dark" aria-label="Dark Theme">
               <span></span>
               <span></span>
@@ -27,7 +27,7 @@
             </label>
           </div>
           <div class="group">
-            <input type="radio" name="themeColor" id="theme-color-light" class="hidden peer" />
+            <input type="radio" name="themeColor" id="theme-color-light" class="sr-only peer" />
             <label for="theme-color-light" aria-label="Light Theme">
               <span></span>
               <span></span>
@@ -36,7 +36,7 @@
             </label>
           </div>
           <div class="group">
-            <input type="radio" name="themeColor" id="theme-color-rose" class="hidden peer" />
+            <input type="radio" name="themeColor" id="theme-color-rose" class="sr-only peer" />
             <label for="theme-color-rose" aria-label="Rose Theme">
               <span></span>
               <span></span>
@@ -45,7 +45,7 @@
             </label>
           </div>
           <div class="group">
-            <input type="radio" name="themeColor" id="theme-color-aqua" class="hidden peer" />
+            <input type="radio" name="themeColor" id="theme-color-aqua" class="sr-only peer" />
             <label for="theme-color-aqua" aria-label="Aqua Theme">
               <span></span>
               <span></span>
@@ -54,7 +54,7 @@
             </label>
           </div>
           <div class="group">
-            <input type="radio" name="themeColor" id="theme-color-forest" class="hidden peer" />
+            <input type="radio" name="themeColor" id="theme-color-forest" class="sr-only peer" />
             <label for="theme-color-forest" aria-label="Forest Theme">
               <span></span>
               <span></span>
@@ -63,7 +63,7 @@
             </label>
           </div>
           <div class="group">
-            <input type="radio" name="themeColor" id="theme-color-orbit" class="hidden peer" />
+            <input type="radio" name="themeColor" id="theme-color-orbit" class="sr-only peer" />
             <label for="theme-color-orbit" aria-label="Orbit Theme">
               <span></span>
               <span></span>

--- a/src/features/modal-info/components/tabs/FontTab.astro
+++ b/src/features/modal-info/components/tabs/FontTab.astro
@@ -66,7 +66,7 @@ import Icon from "../../../../components/icons/Icon.astro";
           <div class="group flex flex-col gap-2">
             <h4 class="mb-0! mt-3!" data-i18n="typo.second-option-base"></h4>
             <input type="radio" name="options-font-size" class="sr-only peer" id="option-base-text" checked />
-            <label for="option-base-text" class="w-25 h-25! flex items-center justify-center border-2 border-(--tn-theme-accent) rounded-lg cursor-pointer peer-checked:border-(--tn-theme-contrast)">
+            <label for="option-base-text" class="w-25 h-25! flex items-center justify-center border-2 border-(--tn-theme-accent) rounded-lg cursor-pointer peer-checked:border-(--tn-theme-contrast) peer-focus-visible:border-(--tn-color-text) peer-focus-visible:ring-2 peer-focus-visible:ring-(--tn-color-text)">
               <Icon name="letterA" fill="var(--tn-theme-accent)" className="text-(--tn-theme-contrast) scale-100" strokeWidth={0.5} />
             </label>
           </div>
@@ -74,7 +74,7 @@ import Icon from "../../../../components/icons/Icon.astro";
           <div class="group flex flex-col gap-2">
             <h4 class="mb-0! mt-3!" data-i18n="typo.second-option-medium"></h4>
             <input type="radio" name="options-font-size" class="sr-only peer" id="option-medium-text" />
-            <label for="option-medium-text" class="w-25 h-25! flex items-center justify-center border-2 border-(--tn-theme-accent) rounded-lg cursor-pointer peer-checked:border-(--tn-theme-contrast)">
+            <label for="option-medium-text" class="w-25 h-25! flex items-center justify-center border-2 border-(--tn-theme-accent) rounded-lg cursor-pointer peer-checked:border-(--tn-theme-contrast) peer-focus-visible:border-(--tn-color-text) peer-focus-visible:ring-2 peer-focus-visible:ring-(--tn-color-text)">
               <Icon name="letterA" fill="var(--tn-theme-accent)" className="text-(--tn-theme-contrast) scale-150" strokeWidth={0.5} />
             </label>
           </div>
@@ -82,7 +82,7 @@ import Icon from "../../../../components/icons/Icon.astro";
           <div class="group flex flex-col gap-2">
             <h4 class="mb-0! mt-3!" data-i18n="typo.second-option-large"></h4>
             <input type="radio" name="options-font-size" class="sr-only peer" id="option-large-text" />
-            <label for="option-large-text" class="w-25 h-25! flex items-center justify-center border-2 border-(--tn-theme-accent) rounded-lg cursor-pointer peer-checked:border-(--tn-theme-contrast)">
+            <label for="option-large-text" class="w-25 h-25! flex items-center justify-center border-2 border-(--tn-theme-accent) rounded-lg cursor-pointer peer-checked:border-(--tn-theme-contrast) peer-focus-visible:border-(--tn-color-text) peer-focus-visible:ring-2 peer-focus-visible:ring-(--tn-color-text)">
               <Icon name="letterA" fill="var(--tn-theme-accent)" className="text-(--tn-theme-contrast) scale-200" strokeWidth={0.5} />
             </label>
           </div>

--- a/src/features/modal-info/modal-info.scss
+++ b/src/features/modal-info/modal-info.scss
@@ -45,6 +45,15 @@
     }
   }
 
+  .nav-item,
+  .save-button {
+    &:focus-visible {
+      outline: 3px solid var(--tn-color-text);
+      outline-offset: 2px;
+      border-radius: 4px;
+    }
+  }
+
   .sidebar-footer {
     margin-top: 1rem;
   }

--- a/src/features/roadmap/roadmap-data.json
+++ b/src/features/roadmap/roadmap-data.json
@@ -38,13 +38,29 @@
           { "summary": "Refactor de atajos de teclado", "description": "Sistema centralizado de atajos con registro por clases, verificación de modificadores (Ctrl/Alt/Shift/Meta), guards por ámbito (system/global) y detección automática de escritorio." },
           { "summary": "Superposición de ayuda de teclado", "description": "Nueva superposición interactiva que lista todos los atajos del teclado agrupados por categoría (Pestañas, Navegación, Editor). Accesible vía botón en la barra lateral o Alt+/." },
           { "summary": "Navegación del modal de configuración", "description": "Mejora en la navegación del modal de ajustes — Enter/Space salta al contenido de la pestaña, Escape regresa a la barra lateral, las flechas ya no se interceptan dentro de controles de formulario." },
-          { "summary": "Corrección Command Palette", "description": "Escape en el command palette ya no se propaga al sistema global, previniendo el cierre accidental de pestañas." }
+          { "summary": "Corrección Command Palette", "description": "Escape en el command palette ya no se propaga al sistema global, previniendo el cierre accidental de pestañas." },
+          { "summary": "Radios de color de tema en el orden de tabulación", "description": "Los radios de color de tema vuelven a estar en el orden de tabulación dentro del modal de configuración." },
+          { "summary": "Navegación por flechas en configuración", "description": "Las flechas del teclado navegan desde el elemento enfocado de la barra lateral del modal de ajustes." },
+          { "summary": "Anillos de foco visibles", "description": "Anillos de foco visibles añadidos para la barra de navegación, guardar y las etiquetas de tamaño de fuente." },
+          { "summary": "Atajos de teclado ignoran el teclado numérico", "description": "Los atajos Alt+número ya no se disparan desde el teclado numérico." },
+          { "summary": "Corrección de auto-desplazamiento en móvil", "description": "El editor ya no se desplaza automáticamente al cambiar el tamaño de fuente en dispositivos móviles." },
+          { "summary": "Tamaño de fuente aplicado a pestañas nuevas", "description": "Las pestañas nuevas aplican el tamaño de fuente guardado en la configuración." },
+          { "summary": "Enlace del changelog restaurado", "description": "El enlace 'Ver changelog completo' vuelve a apuntar a la URL correcta." },
+          { "summary": "Registros de consola solo en desarrollo", "description": "Los registros de consola quedan restringidos a los builds de desarrollo para mantener limpio el bundle de producción." }
         ],
         "en": [
           { "summary": "Keyboard shortcuts refactor", "description": "Centralized class-based shortcut system with modifier matching (Ctrl/Alt/Shift/Meta), scope guards (system/global), and automatic desktop detection." },
           { "summary": "Keyboard shortcuts help overlay", "description": "New interactive overlay listing all keyboard shortcuts grouped by category (Tabs, Navigation, Editor). Accessible via sidebar button or Alt+/." },
           { "summary": "Settings modal navigation", "description": "Enhanced settings modal navigation — Enter/Space jumps into tab content, Escape returns to sidebar, arrows no longer intercepted inside form controls." },
-          { "summary": "Command Palette fix", "description": "Escape in the command palette no longer propagates to the global shortcut system, preventing accidental tab closing." }
+          { "summary": "Command Palette fix", "description": "Escape in the command palette no longer propagates to the global shortcut system, preventing accidental tab closing." },
+          { "summary": "Theme color radios back in tab order", "description": "Theme color radio buttons restored to the tab order inside the settings modal." },
+          { "summary": "Arrow-key navigation in settings", "description": "Arrow keys navigate from the focused settings sidebar item." },
+          { "summary": "Focus-visible rings", "description": "Focus-visible rings added for the navigation bar, save and font-size labels." },
+          { "summary": "Keyboard shortcuts ignore numpad", "description": "Alt+number shortcuts no longer trigger from the numeric keypad." },
+          { "summary": "Mobile auto-scroll fix", "description": "Editor no longer auto-scrolls when changing the font size on mobile." },
+          { "summary": "Saved font size applied to new tabs", "description": "New tabs now apply the saved font size." },
+          { "summary": "Changelog link restored", "description": "The 'View full changelog' link points back to the correct URL." },
+          { "summary": "Console logs gated to development", "description": "Console logs are now restricted to development builds to keep the production bundle clean." }
         ]
       }
     },

--- a/src/i18n/__tests__/i18n.core.test.js
+++ b/src/i18n/__tests__/i18n.core.test.js
@@ -578,6 +578,41 @@ describe("Floating menu tooltip translations (context-menu keys)", () => {
   });
 });
 
+describe("Roadmap changelog keys", () => {
+  let i18n;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    resetI18n();
+    vi.resetModules();
+    const module = await import("../core.js");
+    i18n = module.i18n;
+  });
+
+  const keys = ["roadmap.viewChangelog", "roadmap.changelog-link"];
+
+  ["es", "en"].forEach((lang) => {
+    keys.forEach((key) => {
+      it(`t("${key}") must exist and return a non-empty string in ${lang}`, () => {
+        mockNavigatorLanguage(lang === "es" ? "es-CO" : "en-US");
+        i18n.init();
+        const result = i18n.t(key);
+        expect(result).toBeTruthy();
+        expect(result.length).toBeGreaterThan(0);
+        expect(result).not.toBe(key);
+      });
+    });
+  });
+
+  it('roadmap.changelog-link must point to the Tomanote repo', () => {
+    mockNavigatorLanguage("en-US");
+    i18n.init();
+    const link = i18n.t("roadmap.changelog-link");
+    expect(link).toContain("Tomanote/TomaNote");
+    expect(link).not.toContain("Mixxy-Studio");
+  });
+});
+
 describe("I18nManager - Optional Chaining y null safety", () => {
   let i18n;
 

--- a/src/i18n/core.js
+++ b/src/i18n/core.js
@@ -2,6 +2,7 @@
 // Interanational central system for modules JS
 import es from "../locales/es.json";
 import en from "../locales/en.json";
+import { devLogger } from "../lib/scripts/utils/devLogger.js";
 
 class I18nManager {
   constructor() {
@@ -31,7 +32,7 @@ class I18nManager {
       const fallback = this.translations["es"]?.[key];
       if (fallback !== undefined) return fallback;
 
-      console.warn(`[i18n] Missing translation: "${key}"`);
+      devLogger.warn(`[i18n] Missing translation: "${key}"`);
       return key;
     };
 

--- a/src/lib/scripts/core/__tests__/editorSettings.test.js
+++ b/src/lib/scripts/core/__tests__/editorSettings.test.js
@@ -133,6 +133,30 @@ describe("EditorSettings", () => {
         expect.any(Function),
       );
     });
+
+    it("should wire preventLabelAutoScroll on font size radios", () => {
+      const radio = {
+        id: "option-medium-text",
+        checked: false,
+        addEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      };
+      const label = { addEventListener: vi.fn() };
+      document.querySelectorAll = vi.fn(() => [radio]);
+      document.querySelector = vi.fn(() => label);
+
+      editorSettings.setupFontSizeListener();
+
+      const clickHandler = label.addEventListener.mock.calls.find((c) => c[0] === "click")[1];
+      const mockEvent = { preventDefault: vi.fn() };
+      clickHandler(mockEvent);
+
+      expect(mockEvent.preventDefault).toHaveBeenCalled();
+      expect(radio.checked).toBe(true);
+      expect(radio.dispatchEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "change", bubbles: true }),
+      );
+    });
   });
 
   describe("preventLabelAutoScroll", () => {

--- a/src/lib/scripts/core/__tests__/editorSettings.test.js
+++ b/src/lib/scripts/core/__tests__/editorSettings.test.js
@@ -282,6 +282,11 @@ describe("EditorSettings", () => {
   });
 
   describe("updateLineSpacing", () => {
+    it("should persist fontSize to localStorage", () => {
+      editorSettings.updateLineSpacing("medium");
+      expect(localStorage.setItem).toHaveBeenCalledWith("fontSize", "medium");
+    });
+
     it("should calculate line spacing for base font size", () => {
       editorSettings.updateLineSpacing("base");
       expect(document.documentElement.style.setProperty).toHaveBeenCalledWith(

--- a/src/lib/scripts/core/__tests__/tabs.test.js
+++ b/src/lib/scripts/core/__tests__/tabs.test.js
@@ -334,6 +334,50 @@ describe("TabManager - createTabElement", () => {
 
     expect(tabManager.tabList.appendChild).toHaveBeenCalled();
   });
+
+  it("Aplica ajustes guardados (stretch, bg, font-size) a la nueva pestaña", () => {
+    localStorageMock.getItem.mockImplementation((key) => {
+      if (key === "editorWidth") return "stretch";
+      if (key === "editorBackground") return "underline";
+      if (key === "fontSize") return "medium";
+      return undefined;
+    });
+
+    const tabData = { id: "body-tab-1", name: "Nota", content: "", isPinned: false, emoji: null };
+    const element = tabManager.createTabElement(tabData);
+
+    const innerDiv = element.querySelector(".tab-list__item--content > div");
+    const contentDiv = element.querySelector(".tab-list__item--content");
+    expect(innerDiv.classList.contains("stretch")).toBe(true);
+    expect(contentDiv.classList.contains("bg-underline")).toBe(true);
+    expect(contentDiv.classList.contains("medium-text")).toBe(true);
+  });
+
+  it("No aplica clases si localStorage no tiene ajustes", () => {
+    localStorageMock.getItem.mockReturnValue(undefined);
+
+    const tabData = { id: "body-tab-1", name: "Nota", content: "", isPinned: false, emoji: null };
+    const element = tabManager.createTabElement(tabData);
+
+    const innerDiv = element.querySelector(".tab-list__item--content > div");
+    const contentDiv = element.querySelector(".tab-list__item--content");
+    expect(innerDiv.classList.contains("stretch")).toBe(false);
+    expect(contentDiv.classList.contains("bg-underline")).toBe(false);
+    expect(contentDiv.classList.contains("medium-text")).toBe(false);
+  });
+
+  it("Ignora tamaño de fuente inválido", () => {
+    localStorageMock.getItem.mockImplementation((key) => {
+      if (key === "fontSize") return "huge";
+      return undefined;
+    });
+
+    const tabData = { id: "body-tab-1", name: "Nota", content: "", isPinned: false, emoji: null };
+    const element = tabManager.createTabElement(tabData);
+
+    const contentDiv = element.querySelector(".tab-list__item--content");
+    expect(contentDiv.classList.contains("huge-text")).toBe(false);
+  });
 });
 
 describe("TabManager - reorderTabs", () => {

--- a/src/lib/scripts/core/__tests__/themeManager.test.js
+++ b/src/lib/scripts/core/__tests__/themeManager.test.js
@@ -297,6 +297,30 @@ describe("ThemeManager - setupAppearanceTab", () => {
     expect(mockRadio1.addEventListener).toHaveBeenCalledWith("change", expect.any(Function));
     expect(mockRadio2.addEventListener).toHaveBeenCalledWith("change", expect.any(Function));
   });
+
+  it("Previene auto-scroll al hacer click en los labels de tema", () => {
+    const mockRadio = {
+      id: "theme-color-dark",
+      checked: false,
+      addEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    };
+    const mockLabel = { addEventListener: vi.fn() };
+    document.querySelectorAll = vi.fn(() => [mockRadio]);
+    document.querySelector = vi.fn(() => mockLabel);
+
+    themeManager.setupAppearanceTab();
+
+    const clickHandler = mockLabel.addEventListener.mock.calls.find((c) => c[0] === "click")[1];
+    const mockEvent = { preventDefault: vi.fn() };
+    clickHandler(mockEvent);
+
+    expect(mockEvent.preventDefault).toHaveBeenCalled();
+    expect(mockRadio.checked).toBe(true);
+    expect(mockRadio.dispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "change", bubbles: true })
+    );
+  });
 });
 
 describe("ThemeManager - updateAppearanceTabUI", () => {

--- a/src/lib/scripts/core/editorSettings.js
+++ b/src/lib/scripts/core/editorSettings.js
@@ -67,6 +67,8 @@ export class EditorSettings {
     const fontSizeRadios = document.querySelectorAll('input[name="options-font-size"]');
     if (!fontSizeRadios.length) return;
 
+    this.preventLabelAutoScroll(fontSizeRadios);
+
     fontSizeRadios.forEach((radio) => {
       radio.addEventListener("change", () => {
         const selected = Array.from(fontSizeRadios).find((r) => r.checked);

--- a/src/lib/scripts/core/editorSettings.js
+++ b/src/lib/scripts/core/editorSettings.js
@@ -117,6 +117,7 @@ export class EditorSettings {
   updateLineSpacing(sizeValue) {
     const fontSizePx = FONT_SIZE_PX[sizeValue] || FONT_SIZE_PX.base;
     const lineSpacing = fontSizePx * LINE_HEIGHT;
+    localStorage.setItem("fontSize", sizeValue);
     document.documentElement.style.setProperty("--tn-paper-line-spacing", `${lineSpacing}px`);
   }
 

--- a/src/lib/scripts/core/tabs.js
+++ b/src/lib/scripts/core/tabs.js
@@ -302,6 +302,11 @@ export class TabManager {
       if (savedBg && typeof savedBg === "string" && savedBg !== "flat" && savedBg !== "null") {
         contentDiv.classList.add(`bg-${savedBg}`);
       }
+
+      const savedFontSize = localStorage.getItem("fontSize");
+      if (savedFontSize && ["base", "medium", "large"].includes(savedFontSize)) {
+        contentDiv.classList.add(`${savedFontSize}-text`);
+      }
     }
 
     return tabElement;

--- a/src/lib/scripts/core/themeManager.js
+++ b/src/lib/scripts/core/themeManager.js
@@ -168,6 +168,9 @@ export class ThemeManager {
     // Establecer el radio button activo según el tema actual
     this.updateAppearanceTabUI();
 
+    // Prevenir auto-scroll del modal al hacer clic en los labels (patch mobile)
+    this.preventLabelAutoScroll(themeRadios);
+
     // Agregar event listeners a los radio buttons
     themeRadios.forEach((radio) => {
       radio.addEventListener("change", (e) => {
@@ -181,6 +184,18 @@ export class ThemeManager {
     // Escuchar cambios de tema para actualizar la UI
     window.addEventListener("themeChanged", (e) => {
       this.updateAppearanceTabUI();
+    });
+  }
+
+  preventLabelAutoScroll(radios) {
+    radios.forEach((radio) => {
+      const label = document.querySelector(`label[for="${radio.id}"]`);
+      if (!label) return;
+      label.addEventListener("click", (e) => {
+        e.preventDefault();
+        radio.checked = true;
+        radio.dispatchEvent(new Event("change", { bubbles: true }));
+      });
     });
   }
 

--- a/src/lib/scripts/core/themeManager.js
+++ b/src/lib/scripts/core/themeManager.js
@@ -1,3 +1,5 @@
+import { devLogger } from "../utils/devLogger.js";
+
 export class ThemeManager {
   constructor() {
     this.themes = [
@@ -64,7 +66,7 @@ export class ThemeManager {
         localStorage.setItem("notepadTheme", this.currentTheme);
       }
     } catch (error) {
-      console.warn("⚠️  Error cargando tema:", error);
+      devLogger.warn("⚠️  Error cargando tema:", error);
       this.currentTheme = "dark";
     }
   }
@@ -256,7 +258,7 @@ export class ThemeManager {
 
   switchTheme(themeId) {
     if (!this.themes.some((t) => t.id === themeId)) {
-      console.warn(`⚠️  Tema "${themeId}" no válido`);
+      devLogger.warn(`⚠️  Tema "${themeId}" no válido`);
       return;
     }
 

--- a/src/lib/scripts/entry.js
+++ b/src/lib/scripts/entry.js
@@ -1,9 +1,11 @@
 // src/lib/scripts/entry.js
 // Secure modular entry point for Notepad
+import { devLogger } from "./utils/devLogger.js";
+
 export async function initNotepad() {
   // Security check: only run in browser
   if (typeof window === "undefined" || typeof document === "undefined") {
-    console.warn("⚠️  Entorno no compatible (SSR o Node.js), omitiendo...");
+    devLogger.warn("⚠️  Entorno no compatible (SSR o Node.js), omitiendo...");
     return;
   }
 
@@ -229,7 +231,7 @@ async function initializeFloatingMenu() {
 
     return window.floatingMenu;
   } catch (error) {
-    console.error("❌ Error inicializando FloatingMenu:", error);
+    devLogger.error("❌ Error inicializando FloatingMenu:", error);
   }
 }
 
@@ -245,7 +247,7 @@ async function initializeKeyboardShortcuts() {
 
     return window.keyboardShortcuts;
   } catch (error) {
-    console.error("❌ Error inicializando KeyboardShortcuts:", error);
+    devLogger.error("❌ Error inicializando KeyboardShortcuts:", error);
   }
 }
 
@@ -261,7 +263,7 @@ async function initializeKeyboardShortcutsHelp() {
 
     return window.keyboardShortcutsHelp;
   } catch (error) {
-    console.error("❌ Error inicializando KeyboardShortcutsHelp:", error);
+    devLogger.error("❌ Error inicializando KeyboardShortcutsHelp:", error);
   }
 }
 
@@ -277,7 +279,7 @@ async function initializeTabDragDrop() {
 
     return window.tabDragDrop;
   } catch (error) {
-    console.error("❌ Error inicializando TabDragDrop:", error);
+    devLogger.error("❌ Error inicializando TabDragDrop:", error);
   }
 }
 
@@ -293,7 +295,7 @@ async function initializeSettingsModal() {
 
     return window.settingsModal;
   } catch (error) {
-    console.error("❌ Error inicializando SettingsModal:", error);
+    devLogger.error("❌ Error inicializando SettingsModal:", error);
   }
 }
 
@@ -304,9 +306,9 @@ async function initializeCloseTabConfirmation() {
     window.closeTabConfirmationModal = new CloseTabConfirmation();
     await window.closeTabConfirmationModal.init();
 
-    console.log("[CloseTabConfirmation] Initialized");
+    devLogger.log("[CloseTabConfirmation] Initialized");
   } catch (error) {
-    console.error("❌ Error inicializando CloseTabConfirmation:", error);
+    devLogger.error("❌ Error inicializando CloseTabConfirmation:", error);
   }
 }
 
@@ -317,7 +319,7 @@ async function initializeFloatingNavPosition() {
     window.floatingNavPosition = new FloatingNavPosition();
     window.floatingNavPosition.init();
   } catch (error) {
-    console.error("❌ Error inicializando FloatingNavPosition:", error);
+    devLogger.error("❌ Error inicializando FloatingNavPosition:", error);
   }
 }
 
@@ -333,7 +335,7 @@ async function initializeCommandPalette() {
 
     return window.commandPalette;
   } catch (error) {
-    console.error("❌ Error inicializando CommandPalette:", error);
+    devLogger.error("❌ Error inicializando CommandPalette:", error);
   }
 }
 
@@ -344,7 +346,7 @@ async function initializeEditorSettings() {
     window.editorSettings = new EditorSettings();
     window.editorSettings.init();
   } catch (error) {
-    console.error("❌ Error inicializando EditorSettings:", error);
+    devLogger.error("❌ Error inicializando EditorSettings:", error);
   }
 }
 
@@ -410,7 +412,7 @@ async function emergencyFallback() {
     };
   }
 
-  console.log("🆘 Modo emergencia activado");
+  devLogger.log("🆘 Modo emergencia activado");
 }
 
 function showErrorMessage() {

--- a/src/lib/scripts/ui/__tests__/keyboardShortcuts.test.js
+++ b/src/lib/scripts/ui/__tests__/keyboardShortcuts.test.js
@@ -112,6 +112,13 @@ describe("KeyboardShortcuts", () => {
         key: "k", label: "Ctrl+K", description: "Command Palette", category: "navigation", scope: "system",
       });
     });
+
+    it("stores location restriction for top-row keys and undefined otherwise", () => {
+      expect(ks.shortcuts.find((s) => s.key === "1")).toMatchObject({ location: 0 });
+      expect(ks.shortcuts.find((s) => s.key === ",")).toMatchObject({ location: 0 });
+      expect(ks.shortcuts.find((s) => s.key === ".")).toMatchObject({ location: 0 });
+      expect(ks.shortcuts.find((s) => s.key === "n").location).toBeUndefined();
+    });
   });
 
   // ─── matchesKey ───
@@ -143,6 +150,18 @@ describe("KeyboardShortcuts", () => {
 
     it("rejects when extra modifier is pressed", () => {
       expect(ks.matchesKey(e("n", { altKey: true, ctrlKey: true, location: 1 }), s("n", { alt: true, ctrl: false, shift: false, meta: false }))).toBe(false);
+    });
+
+    it("accepts key when shortcut has no location restriction", () => {
+      expect(ks.matchesKey(e("1", { altKey: true, location: 3 }), s("1"))).toBe(true);
+    });
+
+    it("matches when location matches shortcut restriction", () => {
+      expect(ks.matchesKey(e("1", { altKey: true, location: 0 }), { ...s("1"), location: 0 })).toBe(true);
+    });
+
+    it("rejects numpad key when shortcut restricts to top row (location 0)", () => {
+      expect(ks.matchesKey(e("1", { altKey: true, location: 3 }), { ...s("1"), location: 0 })).toBe(false);
     });
   });
 
@@ -297,7 +316,7 @@ describe("KeyboardShortcuts", () => {
         if (sel === '.tab-list input[type="radio"]:checked') return tabs[1];
         return null;
       });
-      fire(",");
+      fire(",", { location: 0 });
       expect(tabs[0].checked).toBe(true);
     });
 
@@ -308,14 +327,14 @@ describe("KeyboardShortcuts", () => {
         if (sel === '.tab-list input[type="radio"]:checked') return tabs[1];
         return null;
       });
-      fire(".");
+      fire(".", { location: 0 });
       expect(tabs[2].checked).toBe(true);
     });
 
     it("Alt+1 jumps to tab 1", () => {
       const tabs = [{ checked: false }, { checked: false }];
       document.querySelectorAll = vi.fn().mockReturnValue(tabs);
-      fire("1");
+      fire("1", { location: 0 });
       expect(tabs[0].checked).toBe(true);
     });
 
@@ -323,8 +342,38 @@ describe("KeyboardShortcuts", () => {
       const tabs = [{ checked: false }, { checked: false }, { checked: false }];
       document.querySelectorAll = vi.fn().mockReturnValue(tabs);
       const origChecked = tabs.map((t) => t.checked);
-      fire("5");
+      fire("5", { location: 0 });
       expect(tabs.map((t) => t.checked)).toEqual(origChecked);
+    });
+
+    it("Alt+1 from numpad does NOT jump to tab", () => {
+      const tabs = [{ checked: false }, { checked: false }];
+      document.querySelectorAll = vi.fn().mockReturnValue(tabs);
+      const origChecked = tabs.map((t) => t.checked);
+      fire("1", { location: 3 });
+      expect(tabs.map((t) => t.checked)).toEqual(origChecked);
+    });
+
+    it("Alt+, from numpad decimal does NOT go to previous tab", () => {
+      const tabs = [{ checked: false }, { checked: true }, { checked: false }];
+      document.querySelectorAll = vi.fn().mockReturnValue(tabs);
+      document.querySelector = vi.fn((sel) => {
+        if (sel === '.tab-list input[type="radio"]:checked') return tabs[1];
+        return null;
+      });
+      fire(",", { location: 3 });
+      expect(tabs.map((t) => t.checked)).toEqual([false, true, false]);
+    });
+
+    it("Alt+. from numpad decimal does NOT go to next tab", () => {
+      const tabs = [{ checked: false }, { checked: true }, { checked: false }];
+      document.querySelectorAll = vi.fn().mockReturnValue(tabs);
+      document.querySelector = vi.fn((sel) => {
+        if (sel === '.tab-list input[type="radio"]:checked') return tabs[1];
+        return null;
+      });
+      fire(".", { location: 3 });
+      expect(tabs.map((t) => t.checked)).toEqual([false, true, false]);
     });
 
     it("Alt+S opens settings modal", () => {

--- a/src/lib/scripts/ui/__tests__/settingsModal.test.js
+++ b/src/lib/scripts/ui/__tests__/settingsModal.test.js
@@ -338,6 +338,24 @@ describe("SettingsModal", () => {
       expect(event.preventDefault).toHaveBeenCalled();
     });
 
+    it("should navigate from the focused nav-item index, not the active one", async () => {
+      settingsModal = new SettingsModal({ debug: false });
+      await settingsModal.init();
+
+      const keydownHandler = mockModal.addEventListener.mock.calls.find(
+        (call) => call[0] === "keydown",
+      )[1];
+
+      Object.defineProperty(document, "activeElement", {
+        value: mockNavItems[1],
+        configurable: true,
+      });
+
+      const event = { key: "ArrowUp", preventDefault: vi.fn() };
+      keydownHandler(event);
+      expect(mockNavItems[0].focus).toHaveBeenCalled();
+    });
+
     it("should not call switchTab on ArrowDown when nav-item not focused", async () => {
       settingsModal = new SettingsModal({ debug: false });
       await settingsModal.init();

--- a/src/lib/scripts/ui/floatingMenu.js
+++ b/src/lib/scripts/ui/floatingMenu.js
@@ -3,6 +3,7 @@
 
 import { FormattingUtils } from "../utils/formatting.js";
 import { detectEmojiInText, getRandomPinEmoji } from "../utils/emojiDetector.js";
+import { devLogger } from "../utils/devLogger.js";
 
 export class FloatingMenu {
   constructor(options = {}) {
@@ -385,7 +386,7 @@ export class FloatingMenu {
 
   log(...args) {
     if (this.options.debug) {
-      console.log("[FloatingMenu]", ...args);
+      devLogger.log("[FloatingMenu]", ...args);
     }
   }
 }

--- a/src/lib/scripts/ui/floatingNavPosition.js
+++ b/src/lib/scripts/ui/floatingNavPosition.js
@@ -1,3 +1,5 @@
+import { devLogger } from "../utils/devLogger.js";
+
 export class FloatingNavPosition {
   constructor() {
     this.navElement = null;
@@ -13,7 +15,7 @@ export class FloatingNavPosition {
     this.updatePosition();
     this.setupEventListeners();
 
-    console.log("[FloatingNavPosition] Initialized");
+    devLogger.log("[FloatingNavPosition] Initialized");
     return this;
   }
 

--- a/src/lib/scripts/ui/keyboardShortcuts.js
+++ b/src/lib/scripts/ui/keyboardShortcuts.js
@@ -37,6 +37,7 @@ export class KeyboardShortcuts {
     this.shortcuts.push({
       key: config.key,
       modifiers: config.modifiers || {},
+      location: config.location ?? undefined,
       handler: config.handler,
       scope: config.scope || "global",
       preventDefault: config.preventDefault !== false,
@@ -82,6 +83,7 @@ export class KeyboardShortcuts {
 
   matchesKey(e, s) {
     if (e.key !== s.key) return false;
+    if (s.location !== undefined && e.location !== s.location) return false;
     const m = s.modifiers;
 
     if (m.ctrl !== undefined && e.ctrlKey !== m.ctrl) return false;
@@ -176,6 +178,7 @@ export class KeyboardShortcuts {
     this.registerShortcut({
       key: ",",
       modifiers: { alt: true, ctrl: false, shift: false, meta: false },
+      location: 0,
       label: "Alt+,",
       description: "Previous tab",
       category: "tabs",
@@ -194,6 +197,7 @@ export class KeyboardShortcuts {
     this.registerShortcut({
       key: ".",
       modifiers: { alt: true, ctrl: false, shift: false, meta: false },
+      location: 0,
       label: "Alt+.",
       description: "Next tab",
       category: "tabs",
@@ -213,6 +217,7 @@ export class KeyboardShortcuts {
       this.registerShortcut({
         key: String(i),
         modifiers: { alt: true, ctrl: false, shift: false, meta: false },
+        location: 0,
         label: `Alt+${i}`,
         description: `Jump to tab #${i}`,
         category: "tabs",

--- a/src/lib/scripts/ui/keyboardShortcuts.js
+++ b/src/lib/scripts/ui/keyboardShortcuts.js
@@ -1,6 +1,8 @@
 // src/lib/scripts/ui/keyboardShortcuts.js
 // Desktop keyboard shortcut system with centralized registry
 
+import { devLogger } from "../utils/devLogger.js";
+
 export class KeyboardShortcuts {
   constructor(options = {}) {
     this.options = {
@@ -372,7 +374,7 @@ export class KeyboardShortcuts {
 
   log(...args) {
     if (this.options.debug) {
-      console.log("[KeyboardShortcuts]", ...args);
+      devLogger.log("[KeyboardShortcuts]", ...args);
     }
   }
 }

--- a/src/lib/scripts/ui/settingsModal.js
+++ b/src/lib/scripts/ui/settingsModal.js
@@ -1,4 +1,6 @@
 // src/lib/scripts/ui/settingsModal.js
+import { devLogger } from "../utils/devLogger.js";
+
 export class SettingsModal {
   constructor(options = {}) {
     this.options = {
@@ -14,7 +16,7 @@ export class SettingsModal {
     this.modal = document.getElementById("info-notepad");
     if (!this.modal) {
       if (this.options.debug) {
-        console.error("[SettingsModal] Modal not found");
+        devLogger.error("[SettingsModal] Modal not found");
       }
       return this;
     }
@@ -24,7 +26,7 @@ export class SettingsModal {
     this.setupKeyboardNav();
 
     if (this.options.debug) {
-      console.log("[SettingsModal] Initialized successfully");
+      devLogger.log("[SettingsModal] Initialized successfully");
     }
 
     return this;

--- a/src/lib/scripts/ui/settingsModal.js
+++ b/src/lib/scripts/ui/settingsModal.js
@@ -96,8 +96,8 @@ export class SettingsModal {
       const activeEl = document.activeElement;
       const isNavFocused = activeEl && activeEl.classList.contains("nav-item");
 
-      const currentActive = this.modal.querySelector(".nav-item.active");
-      let currentIndex = currentActive ? Array.from(navItems).indexOf(currentActive) : 0;
+      let currentIndex = isNavFocused ? Array.from(navItems).indexOf(activeEl) : 0;
+      if (currentIndex < 0) currentIndex = 0;
 
       // Arrow keys: navigate nav-items only when a nav-item is focused
       if (isNavFocused) {

--- a/src/lib/scripts/ui/tabDragDrop.js
+++ b/src/lib/scripts/ui/tabDragDrop.js
@@ -1,6 +1,7 @@
 // src/lib/scripts/ui/tabDragDrop.js
 // Drag and drop system for tabs using SortableJS
 import Sortable from "sortablejs";
+import { devLogger } from "../utils/devLogger.js";
 
 export class TabDragDrop {
   constructor(options = {}) {
@@ -187,7 +188,7 @@ export class TabDragDrop {
 
   log(...args) {
     if (this.options.debug) {
-      console.log("[TabDragDrop]", ...args);
+      devLogger.log("[TabDragDrop]", ...args);
     }
   }
 }

--- a/src/lib/scripts/utils/devLogger.js
+++ b/src/lib/scripts/utils/devLogger.js
@@ -1,0 +1,16 @@
+const IS_DEV = import.meta.env.DEV === true;
+
+export const devLogger = {
+  log: (...args) => {
+    if (IS_DEV) console.log(...args);
+  },
+  warn: (...args) => {
+    if (IS_DEV) console.warn(...args);
+  },
+  error: (...args) => {
+    if (IS_DEV) console.error(...args);
+  },
+  info: (...args) => {
+    if (IS_DEV) console.info(...args);
+  },
+};

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -220,5 +220,7 @@
   "roadmap.prev-050.4.summary": "Smart tooltips",
   "roadmap.prev-050.4.description": "All buttons now have smart tooltips with sidebar-aware positioning.",
   "roadmap.prev-050.5.summary": "Test coverage",
-  "roadmap.prev-050.5.description": "455 tests passing — expanded coverage for editor settings, command palette, floating menu, and utilities."
+  "roadmap.prev-050.5.description": "455 tests passing — expanded coverage for editor settings, command palette, floating menu, and utilities.",
+  "roadmap.viewChangelog": "View full changelog →",
+  "roadmap.changelog-link": "https://github.com/Tomanote/TomaNote/blob/master/CHANGELOG.md"
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -222,5 +222,21 @@
   "roadmap.prev-050.5.summary": "Test coverage",
   "roadmap.prev-050.5.description": "455 tests passing — expanded coverage for editor settings, command palette, floating menu, and utilities.",
   "roadmap.viewChangelog": "View full changelog →",
-  "roadmap.changelog-link": "https://github.com/Tomanote/TomaNote/blob/master/CHANGELOG.md"
+  "roadmap.changelog-link": "https://github.com/Tomanote/TomaNote/blob/master/CHANGELOG.md",
+  "roadmap.current.4.summary": "Theme color radios back in tab order",
+  "roadmap.current.4.description": "Theme color radio buttons restored to the tab order inside the settings modal.",
+  "roadmap.current.5.summary": "Arrow-key navigation in settings",
+  "roadmap.current.5.description": "Arrow keys navigate from the focused settings sidebar item.",
+  "roadmap.current.6.summary": "Focus-visible rings",
+  "roadmap.current.6.description": "Focus-visible rings added for the navigation bar, save and font-size labels.",
+  "roadmap.current.7.summary": "Keyboard shortcuts ignore numpad",
+  "roadmap.current.7.description": "Alt+number shortcuts no longer trigger from the numeric keypad.",
+  "roadmap.current.8.summary": "Mobile auto-scroll fix",
+  "roadmap.current.8.description": "Editor no longer auto-scrolls when changing the font size on mobile.",
+  "roadmap.current.9.summary": "Saved font size applied to new tabs",
+  "roadmap.current.9.description": "New tabs now apply the saved font size.",
+  "roadmap.current.10.summary": "Changelog link restored",
+  "roadmap.current.10.description": "The 'View full changelog' link points back to the correct URL.",
+  "roadmap.current.11.summary": "Console logs gated to development",
+  "roadmap.current.11.description": "Console logs are now restricted to development builds to keep the production bundle clean."
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -223,5 +223,21 @@
   "roadmap.prev-050.5.summary": "Cobertura de tests",
   "roadmap.prev-050.5.description": "455 tests pasando — cobertura expandida para configuración del editor, command palette, menú flotante y utilidades.",
   "roadmap.viewChangelog": "Ver changelog completo →",
-  "roadmap.changelog-link": "https://github.com/Tomanote/TomaNote/blob/master/CHANGELOG.md"
+  "roadmap.changelog-link": "https://github.com/Tomanote/TomaNote/blob/master/CHANGELOG.md",
+  "roadmap.current.4.summary": "Radios de color de tema en el orden de tabulación",
+  "roadmap.current.4.description": "Los radios de color de tema vuelven a estar en el orden de tabulación dentro del modal de configuración.",
+  "roadmap.current.5.summary": "Navegación por flechas en configuración",
+  "roadmap.current.5.description": "Las flechas del teclado navegan desde el elemento enfocado de la barra lateral del modal de ajustes.",
+  "roadmap.current.6.summary": "Anillos de foco visibles",
+  "roadmap.current.6.description": "Anillos de foco visibles añadidos para la barra de navegación, guardar y las etiquetas de tamaño de fuente.",
+  "roadmap.current.7.summary": "Atajos de teclado ignoran el teclado numérico",
+  "roadmap.current.7.description": "Los atajos Alt+número ya no se disparan desde el teclado numérico.",
+  "roadmap.current.8.summary": "Corrección de auto-desplazamiento en móvil",
+  "roadmap.current.8.description": "El editor ya no se desplaza automáticamente al cambiar el tamaño de fuente en dispositivos móviles.",
+  "roadmap.current.9.summary": "Tamaño de fuente aplicado a pestañas nuevas",
+  "roadmap.current.9.description": "Las pestañas nuevas aplican el tamaño de fuente guardado en la configuración.",
+  "roadmap.current.10.summary": "Enlace del changelog restaurado",
+  "roadmap.current.10.description": "El enlace 'Ver changelog completo' vuelve a apuntar a la URL correcta.",
+  "roadmap.current.11.summary": "Registros de consola solo en desarrollo",
+  "roadmap.current.11.description": "Los registros de consola quedan restringidos a los builds de desarrollo para mantener limpio el bundle de producción."
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -221,5 +221,7 @@
   "roadmap.prev-050.4.summary": "Tooltips inteligentes",
   "roadmap.prev-050.4.description": "Todos los botones ahora tienen tooltips con posicionamiento inteligente según la barra lateral.",
   "roadmap.prev-050.5.summary": "Cobertura de tests",
-  "roadmap.prev-050.5.description": "455 tests pasando — cobertura expandida para configuración del editor, command palette, menú flotante y utilidades."
+  "roadmap.prev-050.5.description": "455 tests pasando — cobertura expandida para configuración del editor, command palette, menú flotante y utilidades.",
+  "roadmap.viewChangelog": "Ver changelog completo →",
+  "roadmap.changelog-link": "https://github.com/Tomanote/TomaNote/blob/master/CHANGELOG.md"
 }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -34,12 +34,13 @@ import KeyboardShortcutsHelp from "../features/keyboard-shortcuts-help/keyboard-
 
 <script>
   import { initNotepad } from "../lib/scripts/entry.js";
+  import { devLogger } from "../lib/scripts/utils/devLogger.js";
 
   // Inicializar de forma segura con timeout
   document.addEventListener("DOMContentLoaded", () => {
     setTimeout(() => {
       initNotepad().catch((error) => {
-        console.error("Error en sistema modular:", error);
+        devLogger.error("Error en sistema modular:", error);
       });
     }, 100); // Pequeño delay para asegurar que el DOM está listo
   });

--- a/src/styles/components/ThemeSelector.scss
+++ b/src/styles/components/ThemeSelector.scss
@@ -41,6 +41,12 @@
         outline-offset: 2px;
         border-radius: 10px;
       }
+
+      &:has(input:focus-visible) {
+        outline: 3px solid var(--tn-color-text);
+        outline-offset: 2px;
+        border-radius: 10px;
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- **Hotfixes (PR #56 → dev)**: settings modal tab order and focus-visible rings, arrow-key navigation, numpad ignored for Alt+number shortcuts, saved font size applied to new tabs, mobile auto-scroll fix, changelog link restored, console logs gated to development (`devLogger`).
- **Docs**: new English `CONTRIBUTING.md` with all project conventions (branching, conventional commits, self-contained commits, required quality checks, i18n/roadmap and logging conventions).
- **CI**: new `build-and-test` workflow (`.github/workflows/ci.yml`) running `astro check` + tests + production build on PRs to `master`/`dev` and pushes to `master`. This is the status check required by the `master` ruleset.
- **Roadmap/Changelog/README**: v0.5.1 current version now lists the 8 hotfix items (ES/EN); `CHANGELOG.md` regenerated; README updated to v0.5.1 with fixed repo links (`Tomanote/TomaNote`) and 508 passing tests.

## Tests & checks
- `npm run test:run`: 508 tests passing
- `npm run build`: production build OK
- `npx astro check`: 0 errors